### PR TITLE
Fix travis linux py8 build

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -14,11 +14,14 @@ services:
 env:
  - CONDA_RECIPE=conda
    CONDA_VERSION=3
-   CONDA_PY=37   
+   CONDA_PY=37
  - CONDA_RECIPE=conda
    CONDA_VERSION=3
    CONDA_PY=38
    CONDA_NPY=116
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -y install libgl1-mesa-dev; fi
 
 install:
   - git clone https://github.com/openalea/travis-ci.git


### PR DESCRIPTION
This should fix at least the py38 build. py37 still fails with the same error message:

`CMake Error at /home/travis/miniconda/conda-bld/openalea.plantgl_1600234224504/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake:9 (message):
  Failed to find "GL/gl.h" in`

osx:

I think you need to specify the osx image and set the SDK env accordingly. Not sure where this setting is.

> Travis CI uses macOS 10.13 and Xcode 9.4.1 by default.

```
CMake Warning at /Users/travis/miniconda/conda-bld/openalea.plantgl_1600088352785/_build_env/share/cmake-3.18/Modules/Platform/Darwin-Initialize.cmake:286 (message):

  Ignoring CMAKE_OSX_SYSROOT value:
   /opt/MacOSX10.10.sdk

  because the directory does not exist.
```

windows:

Seems to be an issue with the code itself:

```
%PREFIX%\Library\include\boost/heap/detail/heap_node.hpp(145): error C2300: 'boost::heap::detail::marked_heap_node<unsigned int>': class does not have a destructor called '~Node'
%PREFIX%\Library\include\boost/heap/detail/heap_node.hpp(142): note: while compiling class template member function 'void boost::heap::detail::node_disposer<boost::heap::detail::heap_node<value_type,true>,boost::heap::detail::heap_node_base<false>,Alloc>::operator ()(NodeBase *)'
```

